### PR TITLE
opentelemetry-proto-support-feature-gen-grpcio-messages

### DIFF
--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -31,7 +31,8 @@ full = ["gen-tonic", "gen-grpcio", "trace", "logs", "metrics", "zpages", "with-s
 # crates used to generate rs files
 gen-tonic = ["gen-tonic-messages", "tonic/transport"]
 gen-tonic-messages = ["tonic", "prost"]
-gen-grpcio = ["grpcio", "prost"]
+gen-grpcio = ["gen-grpcio-messages", "grpcio"]
+gen-grpcio-messages = ["prost"]
 
 # telemetry pillars and functions
 trace = ["opentelemetry/trace", "opentelemetry_sdk/trace"]

--- a/opentelemetry-proto/src/lib.rs
+++ b/opentelemetry-proto/src/lib.rs
@@ -32,10 +32,13 @@
 #[doc(hidden)]
 mod proto;
 
-#[cfg(feature = "gen-grpcio")]
+#[cfg(feature = "gen-grpcio-messages")]
 pub use proto::grpcio;
 
 #[cfg(feature = "gen-tonic-messages")]
 pub use proto::tonic;
 
-mod transform;
+pub mod transform;
+
+#[cfg(feature = "gen-grpcio-messages")]
+pub use prost;

--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -76,10 +76,11 @@ pub mod tonic {
     pub use crate::transform::common::tonic::Attributes;
 }
 
-#[cfg(feature = "gen-grpcio")]
+#[cfg(feature = "gen-grpcio-messages")]
 /// Generated files using [`grpcio`](https://docs.rs/crate/grpcio) and [`grpcio-compiler`](https://docs.rs/grpcio-compiler)
 pub mod grpcio {
     /// Service stub and clients
+    #[cfg(feature = "gen-grpcio")]
     #[path = ""]
     pub mod collector {
         #[cfg(feature = "logs")]

--- a/opentelemetry-proto/src/transform/common.rs
+++ b/opentelemetry-proto/src/transform/common.rs
@@ -1,11 +1,11 @@
 #[cfg(all(
-    any(feature = "gen-tonic-messages", feature = "gen-grpcio"),
+    any(feature = "gen-tonic-messages", feature = "gen-grpcio-messages"),
     any(feature = "trace", feature = "metrics", feature = "logs")
 ))]
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[cfg(all(
-    any(feature = "gen-tonic-messages", feature = "gen-grpcio"),
+    any(feature = "gen-tonic-messages", feature = "gen-grpcio-messages"),
     any(feature = "trace", feature = "metrics", feature = "logs")
 ))]
 pub(crate) fn to_nanos(time: SystemTime) -> u64 {
@@ -138,7 +138,7 @@ pub mod tonic {
     }
 }
 
-#[cfg(feature = "gen-grpcio")]
+#[cfg(feature = "gen-grpcio-messages")]
 pub mod grpcio {
     use crate::proto::grpcio::common::v1::{
         any_value, AnyValue, ArrayValue, InstrumentationScope, KeyValue,

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -343,7 +343,7 @@ pub mod tonic {
     }
 }
 
-#[cfg(feature = "gen-grpcio")]
+#[cfg(feature = "gen-grpcio-messages")]
 pub mod grpcio {
     use std::any::Any;
     use std::fmt;

--- a/opentelemetry-proto/src/transform/trace.rs
+++ b/opentelemetry-proto/src/transform/trace.rs
@@ -109,7 +109,7 @@ pub mod tonic {
     }
 }
 
-#[cfg(feature = "gen-grpcio")]
+#[cfg(feature = "gen-grpcio-messages")]
 pub mod grpcio {
     use crate::proto::grpcio::resource::v1::Resource;
     use crate::proto::grpcio::trace::v1::{span, status, ResourceSpans, ScopeSpans, Span, Status};


### PR DESCRIPTION

In some cases (e.g. rust wasm), it is not possible to have network-related crates (e.g. grpcio) included, and we would like to support protobuf encoding support. so similar to the feature `gen-tonic-messages`, here introduce a feature  `gen-grpcio-messages` to support protobuf encoding without any network client/server included.
